### PR TITLE
Add TenerifeTech

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Todas las sugerencias y contribuciones son bienvenidas. Si tienes alguna, por fa
 - [Python Madrid](https://python-madrid-learn.herokuapp.com)
 - [Scala Barcelona](http://slack.scalabcn.org/)
 - [ScalaEs](http://scalaes-register.herokuapp.com/)
+- [TenerifeTech](https://slackin-tenerifetech.herokuapp.com/)
 - [Valencia Devs](http://slack.vlctechhub.org)
 - [WordPress Alicante](https://wpalicante.slack.com)
 - [WordPress Madrid](http://wpmadrid.es/wp-login.php?action=slack-invitation)


### PR DESCRIPTION
I added the invitation URL, but it would be a good idea also to have the slack URL, e.g. https://tenerifetech.slack.com/